### PR TITLE
Search by CPE and (optionally) description

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Use `-h` or `--help` to obtain all the usage information:
 
 ```bash
 :~$ python3 tapir.py -h
-usage: tapir.py [-h] [-s] -y YEAR [-c COUNT] search
+usage: tapir.py [-h] [-s] [-d] -y YEAR [-c COUNT] search
 
 Search CVEs on NIST data
 
@@ -32,6 +32,8 @@ positional arguments:
 options:
   -h, --help            show this help message and exit
   -s, --short           Print short version of each CVE entry
+  -d, --search-description
+                        Search in CVE description too
   -y YEAR, --year YEAR  Year to look for. Examples: '2020' (single) or '2019,2020' (list) or '2010-2020' (range)
   -c COUNT, --count COUNT
                         Number of results to display

--- a/tapir.py
+++ b/tapir.py
@@ -42,7 +42,16 @@ class bcolors:
 
 
 def shorten():
+    """
+    shorten() will output a simple description of the CVEs found
+    instead of the default JSON formatted output.
+    """
     i = len(CVEs)
+
+    if i == 0:
+        print("No CVEs found")
+        return
+
     for entry in CVEs:
         print(f'''
 {bcolors.h('ID')} {
@@ -67,7 +76,7 @@ def shorten():
             print("---")
 
 
-def search(data_json, search_query):
+def search(data_json: object, search_query: str, in_decription: bool = False):
     """
     This function parses the NIST JSON data,
     identifies each CVE, and searches for the
@@ -82,7 +91,23 @@ def search(data_json, search_query):
 
     for entry in data_json['CVE_Items']:
         # Filter for CVE entries
-        if 'cve' in entry:
+        # use CPE entries
+        if ('configurations' in entry and
+                len(entry['configurations']['nodes']) > 0):
+            found = False
+            for node in entry['configurations']['nodes']:
+                for cpe in node['cpe_match']:
+                    if regex.search(cpe['cpe23Uri']) is not None:
+                        CVEs.append(entry)
+                        max_results_counter += 1
+                        found = True
+                        break
+            if found:
+                # if item found already using CPE entry then continue
+                continue
+
+        # use the description as search data
+        if 'cve' in entry and in_decription:
             # Obtain CVE description
             cve_description = entry['cve']['description']
             # Process each description data?
@@ -99,21 +124,19 @@ def search(data_json, search_query):
 
     if short:
         shorten()
-    return
 
 
-def download_nist_data(year):
+def download_nist_data(year: int) -> object:
     """
     Donwload NIST CVE data for a given year
     """
     try:
         data_path = f"{os.getcwd()}/data"
         data_file = f"{data_path}/nvdcve-1.1-{year}.json.gz"
-        data_url = "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{YEAR}.json.gz"
-        fetch_url = data_url.replace('{YEAR}', str(year))
+        data_url = f"https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-{str(year)}.json.gz"
 
         # Download NIST data for a given year
-        content = requests.get(fetch_url, headers={"Accept-Encoding": "gzip"})
+        content = requests.get(data_url, headers={"Accept-Encoding": "gzip"})
 
         # If download was not successful raise exception
         if content.status_code != 200:
@@ -126,17 +149,17 @@ def download_nist_data(year):
         # Second, load it as JSON
         try:
             data = json.loads(gzip.decompress(content.content))
-        except json.decoder.JSONDecodeError:
-            raise Exception("Error decoding NIST JSON")
+        except json.decoder.JSONDecodeError as err:
+            raise Exception(f"Error decoding NIST JSON: {err}")
 
         return data
 
     except Exception as err:
         print(f"Exception in download_nist_data: {err}")
-        return False
+        return None
 
 
-def retrieve_nist_data_from_cache(year):
+def retrieve_nist_data_from_cache(year: int) -> object:
     """
     Check local cache if NIST data for a given
     year already exists. If yes, use it.
@@ -149,16 +172,15 @@ def retrieve_nist_data_from_cache(year):
         nist_file = f"{data_path}/{data_file.replace('{YEAR}', str(year))}"
 
         # Check if file exists in path
-        if os.path.exists(nist_file):
-            if os.path.getsize(nist_file) > 30000:
-                with gzip.open(nist_file,'rb') as nist_data:
-                    try:
-                        return json.loads(nist_data.read())
-                    except json.decoder.JSONDecodeError as err:
-                        raise Exception("Error decoding NIST JSON")
+        if os.path.exists(nist_file) and os.path.getsize(nist_file) > 30000:
+            with gzip.open(nist_file, 'rb') as nist_data:
+                try:
+                    return json.loads(nist_data.read())
+                except json.decoder.JSONDecodeError as err:
+                    raise Exception(f"Error decoding NIST JSON: {err}")
 
         # In any other case, return false
-        return False
+        return None
     except Exception as err:
         print(f"Exception in retrieve_nist_data_from_cache: {err}")
 
@@ -171,6 +193,9 @@ def main():
     parser.add_argument('-s', '--short', default=False,
                         help="Print short version of each CVE entry",
                         action='store_true')
+    parser.add_argument('-d', '--search-description', default=False,
+                        action='store_true',
+                        help='Search in CVE description too')
     parser.add_argument('-y', '--year', required=True, type=str,
                         help="Year to look for. Examples: '2020' (single) \
                         or '2019,2020' (list) or '2010-2020' (range)")
@@ -195,7 +220,7 @@ def main():
         else:
             parser.print_help()
             quit(1)
-    except:
+    except Exception:
         # Parse sequence of years, e.g.: 2011,2012,2013
         search_years = args.year.split(',')
 
@@ -203,17 +228,17 @@ def main():
     for year in search_years:
         # Attempting to retrieve data from local cache
         nist_data = retrieve_nist_data_from_cache(year)
-        if nist_data is False:
+        if not nist_data:
             # If no local cache found, download NIST data for a given year
             nist_data = download_nist_data(year)
 
         # Search in the downloaded data
         if nist_data:
-            search(nist_data, args.search)
+            search(nist_data, args.search, args.search_description)
         else:
             print("Error retrieving NIST data {nist_data}")
 
-    if len(CVEs) > 0 and not short:
+    if not short:
         print(json.dumps(CVEs))
 
 


### PR DESCRIPTION
This changes comes as result of a suggestion made on #11 as it might bring more accurate results for a given single string. Searching for a specific string on the description was made optional by the argument switch `--search-description`.

Along with that change, other simple changes were done for clarity and also to comply with Flake.